### PR TITLE
Fix Safari and Internet Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "detect-element-resize": "./bower_components/javascript-detect-element-resize/jquery.resize.js",
     "highlightjs": "./bower_components/highlightjs/highlight.pack.js",
     "pdfjs": "./bower_components/pdfjs-dist/build/pdf.js",
+    "pdfjs-compatibility": "./bower_components/pdfjs-dist/web/compatibility.js",
     "mentio": "./bower_components/ment.io/dist/mentio.js",
     "jquery": "./bower_components/jquery/dist/jquery.js",
     "kramed": "./bower_components/kramed/lib/kramed.js",
@@ -115,6 +116,11 @@
     },
     "pdfjs": {
       "exports": "PDFJS"
+    },
+    "pdfjs-compatibility": {
+      "depends": [
+        "pdfjs:PDFJS"
+      ]
     },
     "highlightjs": {
       "exports": "hljs"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -19,6 +19,7 @@
   require('angular-route-segment'); // provides 'route-segment' module
   require('../../tmp/templates.js'); // provides 'templates' module
   require('pdfjs');
+  require('pdfjs-compatibility');
   require('../../bower_components/pdfjs-dist/web/pdf_viewer.js');
 
   var paperhive = angular

--- a/src/less/paperhive/navbar.less
+++ b/src/less/paperhive/navbar.less
@@ -16,6 +16,7 @@ body {
 
 .ph-title-logo {
   max-width:35px;
+  max-height:35px;
   margin-top: -7px;
 }
 


### PR DESCRIPTION
* Fixes pdfjs issues in Safari and Internet Explorer by including pdfjs' compatibility.js
* Fixes rendering of the navbar svg logo in Internet Explorer by explicitly setting the max-height property

Tested on Safari 5.1.10 and Internet Explorer 11.0.

Fixes #69.