### PR TITLE
Simplify metadata handling and add descriptions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,29 +6,13 @@
     <base href="<%= config.baseHref %>">
     <title data-ng-bind="metaService.data.title"></title>
     <meta charset="utf-8">
-    <meta
-      ng-if="metaService.data.author"
-      name="author"
-      content="{{metaService.data.author}}"
-      >
-    <meta
-      ng-if="metaService.data.description"
-      name="description"
-      content="{{metaService.data.description}}"
-      >
-    <meta
-      ng-if="metaService.data.keywords"
-      name="keywords"
-      content="{{metaService.data.keywords}}"
-      >
-    <meta
-      ng-if="metaService.data.statusCode != 200"
-      name="prerender-status-code"
-      content="{{metaService.data.statusCode}}"
-      >
     <meta name="language" content="en">
     <meta name="application-name" content="PaperHive">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      ng-repeat="(name, content) in metaService.data.meta"
+      name="{{name}}" content="{{content}}"
+      >
     <!-- TODO: bundle mathjax in index.js -->
     <script src="assets/mathjax/MathJax.js?config=TeX-AMS_HTML-full,Safe">
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -10,8 +10,8 @@
     <meta name="application-name" content="PaperHive">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
-      ng-repeat="(name, content) in metaService.data.meta"
-      name="{{name}}" content="{{content}}"
+      ng-repeat="meta in metaService.data.meta"
+      name="{{meta.name}}" content="{{meta.content}}"
       >
     <!-- TODO: bundle mathjax in index.js -->
     <script src="assets/mathjax/MathJax.js?config=TeX-AMS_HTML-full,Safe">

--- a/src/js/config/index.js
+++ b/src/js/config/index.js
@@ -3,7 +3,7 @@ module.exports = function(app) {
   require('./animate')(app);
   require('./html5Mode')(app);
   require('./mathjax.js')(app);
-  require('./pageTitleUpdate.js')(app);
+  require('./metaUpdate.js')(app);
   require('./pdf.js')(app);
   require('./routes.js')(app);
   require('./scroll.js')(app);

--- a/src/js/config/metaUpdate.js
+++ b/src/js/config/metaUpdate.js
@@ -12,8 +12,7 @@ module.exports = function(app) {
           $routeSegment.chain[$routeSegment.chain.length - 1].params;
         metaService.set({
           title: params.title || 'PaperHive',
-          description: params.description,
-          statusCode: params.statusCode || 200
+          meta: params.meta
         });
       });
     }

--- a/src/js/config/pageTitleUpdate.js
+++ b/src/js/config/pageTitleUpdate.js
@@ -12,6 +12,7 @@ module.exports = function(app) {
           $routeSegment.chain[$routeSegment.chain.length - 1].params;
         metaService.set({
           title: params.title || 'PaperHive',
+          description: params.description,
           statusCode: params.statusCode || 200
         });
       });

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -35,7 +35,10 @@ module.exports = function(app) {
         // Init Main Page
         .segment('main', {
           templateUrl: 'templates/main/main.html',
-          title: 'PaperHive · Papers, alive.'
+          title: 'PaperHive · Papers, alive.',
+          description: 'Review, discuss, and improve research articles – ' +
+            'together, on the spot and for free. Gain insight from the ' +
+            'findings of others.'
         })
         // 404 page not found
         .segment('404', {
@@ -101,17 +104,22 @@ module.exports = function(app) {
         .segment('contact', {
           templateUrl: 'templates/contact/contact.html',
           controller: 'ContactCtrl',
-          title: 'Contact · PaperHive'
+          title: 'Contact · PaperHive',
+          description: 'Contact PaperHive and ask us questions or send us ' +
+            'suggestions.'
         })
 
         .segment('help', {
           templateUrl: 'templates/help/help.html',
-          title: 'Help · PaperHive'
+          title: 'Help · PaperHive',
+          description: 'Learn how to discuss and review research articles ' +
+            'efficiently and collaboratively on PaperHive.'
         })
 
         .segment('legalnotice', {
           templateUrl: 'templates/legalnotice.html',
-          title: 'Legal notice · PaperHive'
+          title: 'Legal notice · PaperHive',
+          description: 'Information about the operators of PaperHive.'
         })
 
         .segment('oauth', {
@@ -136,7 +144,8 @@ module.exports = function(app) {
 
         .segment('team', {
           templateUrl: 'templates/team/index.html',
-          title: 'Team · PaperHive'
+          title: 'Team · PaperHive',
+          description: 'Meet the team who builds PaperHive.'
         })
 
         .segment('users', {

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -36,19 +36,22 @@ module.exports = function(app) {
         .segment('main', {
           templateUrl: 'templates/main/main.html',
           title: 'PaperHive · Papers, alive.',
-          meta: {
-            description: 'Review, discuss, and improve research articles – ' +
-              'together, on the spot and for free. Gain insight from the ' +
-              'findings of others.'
-          }
+          meta: [
+            {
+              name: 'description',
+              content: 'Review, discuss, and improve research articles – ' +
+                'together, on the spot and for free. Gain insight from the ' +
+                'findings of others.'
+            }
+          ]
         })
         // 404 page not found
         .segment('404', {
           templateUrl: 'templates/shared/404.html',
           title: '404 · page not found · PaperHive',
-          meta: {
-            'prerender-status-code': 404
-          }
+          meta: [
+            {name: 'prerender-status-code', content: 404}
+          ]
         })
 
         .segment('alpha-warning', {
@@ -109,27 +112,36 @@ module.exports = function(app) {
           templateUrl: 'templates/contact/contact.html',
           controller: 'ContactCtrl',
           title: 'Contact · PaperHive',
-          meta: {
-            description: 'Contact PaperHive and ask us questions or send us ' +
-              'suggestions.'
-          }
+          meta: [
+            {
+              name: 'description',
+              content: 'Contact PaperHive and ask us questions or send us ' +
+                'suggestions.'
+            }
+          ]
         })
 
         .segment('help', {
           templateUrl: 'templates/help/help.html',
           title: 'Help · PaperHive',
-          meta: {
-            description: 'Learn how to discuss and review research articles ' +
-              'efficiently and collaboratively on PaperHive.'
-          }
+          meta: [
+            {
+              name: 'description',
+              content: 'Learn how to discuss and review research articles ' +
+                'efficiently and collaboratively on PaperHive.'
+            }
+          ]
         })
 
         .segment('legalnotice', {
           templateUrl: 'templates/legalnotice.html',
           title: 'Legal notice · PaperHive',
-          meta: {
-            description: 'Information about the operators of PaperHive.'
-          }
+          meta: [
+            {
+              name: 'description',
+              content: 'Information about the operators of PaperHive.'
+            }
+          ]
         })
 
         .segment('oauth', {
@@ -155,9 +167,12 @@ module.exports = function(app) {
         .segment('team', {
           templateUrl: 'templates/team/index.html',
           title: 'Team · PaperHive',
-          meta: {
-            description: 'Meet the team that builds PaperHive.'
-          }
+          meta: [
+            {
+              name: 'description',
+              content: 'Meet the team that builds PaperHive.'
+            }
+          ]
         })
 
         .segment('users', {

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -36,15 +36,19 @@ module.exports = function(app) {
         .segment('main', {
           templateUrl: 'templates/main/main.html',
           title: 'PaperHive · Papers, alive.',
-          description: 'Review, discuss, and improve research articles – ' +
-            'together, on the spot and for free. Gain insight from the ' +
-            'findings of others.'
+          meta: {
+            description: 'Review, discuss, and improve research articles – ' +
+              'together, on the spot and for free. Gain insight from the ' +
+              'findings of others.'
+          }
         })
         // 404 page not found
         .segment('404', {
           templateUrl: 'templates/shared/404.html',
           title: '404 · page not found · PaperHive',
-          statusCode: 404
+          meta: {
+            statusCode: 404
+          }
         })
 
         .segment('alpha-warning', {
@@ -105,21 +109,27 @@ module.exports = function(app) {
           templateUrl: 'templates/contact/contact.html',
           controller: 'ContactCtrl',
           title: 'Contact · PaperHive',
-          description: 'Contact PaperHive and ask us questions or send us ' +
-            'suggestions.'
+          meta: {
+            description: 'Contact PaperHive and ask us questions or send us ' +
+              'suggestions.'
+          }
         })
 
         .segment('help', {
           templateUrl: 'templates/help/help.html',
           title: 'Help · PaperHive',
-          description: 'Learn how to discuss and review research articles ' +
-            'efficiently and collaboratively on PaperHive.'
+          meta: {
+            description: 'Learn how to discuss and review research articles ' +
+              'efficiently and collaboratively on PaperHive.'
+          }
         })
 
         .segment('legalnotice', {
           templateUrl: 'templates/legalnotice.html',
           title: 'Legal notice · PaperHive',
-          description: 'Information about the operators of PaperHive.'
+          meta: {
+            description: 'Information about the operators of PaperHive.'
+          }
         })
 
         .segment('oauth', {
@@ -145,7 +155,9 @@ module.exports = function(app) {
         .segment('team', {
           templateUrl: 'templates/team/index.html',
           title: 'Team · PaperHive',
-          description: 'Meet the team who builds PaperHive.'
+          meta: {
+            description: 'Meet the team who builds PaperHive.'
+          }
         })
 
         .segment('users', {

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -156,7 +156,7 @@ module.exports = function(app) {
           templateUrl: 'templates/team/index.html',
           title: 'Team · PaperHive',
           meta: {
-            description: 'Meet the team who builds PaperHive.'
+            description: 'Meet the team that builds PaperHive.'
           }
         })
 

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -47,7 +47,7 @@ module.exports = function(app) {
           templateUrl: 'templates/shared/404.html',
           title: '404 · page not found · PaperHive',
           meta: {
-            statusCode: 404
+            'prerender-status-code': 404
           }
         })
 

--- a/src/js/controllers/activity.js
+++ b/src/js/controllers/activity.js
@@ -10,9 +10,11 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: 'Activity · ' + article.title + ' · PaperHive',
-            author: article.authors.join(', '),
-            description:
-              article.abstract.replace(/(\r\n|\n|\r)/gm, ' ').substring(0, 150)
+            meta: {
+              description: 'Activity for ' + article.title + ' by ' +
+                article.authors.join(', ') + '.',
+              author: article.authors.join(', ')
+            }
           });
         }
       });

--- a/src/js/controllers/activity.js
+++ b/src/js/controllers/activity.js
@@ -10,11 +10,14 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: 'Activity · ' + article.title + ' · PaperHive',
-            meta: {
-              description: 'Activity for ' + article.title + ' by ' +
-                article.authors.join(', ') + '.',
-              author: article.authors.join(', ')
-            }
+            meta: [
+              {
+                name: 'description',
+                content: 'Activity for ' + article.title + ' by ' +
+                  article.authors.join(', ') + '.',
+              },
+              {name: 'author', content: article.authors.join(', ')}
+            ]
           });
         }
       });

--- a/src/js/controllers/article.js
+++ b/src/js/controllers/article.js
@@ -25,14 +25,16 @@ module.exports = function(app) {
         $scope.article = article;
         // Set meta information
         metaService.set({
-          author: article.authors.join(', '),
           title: article.title + ' · PaperHive',
           // Cut description down to 150 chars, cf.
           // <http://moz.com/learn/seo/meta-description>
           // TODO move linebreak removal to backend?
-          description:
-            article.abstract.substring(0, 150).replace(/(\r\n|\n|\r)/gm, ' '),
-          keywords: article.tags.join(', ')
+          meta: {
+            description: article.title + ' by ' + article.authors.join(', ') +
+              '.',
+            author: article.authors.join(', '),
+            keywords: article.tags.join(', ')
+          }
         });
       })
       .error(function(data) {

--- a/src/js/controllers/article.js
+++ b/src/js/controllers/article.js
@@ -29,12 +29,15 @@ module.exports = function(app) {
           // Cut description down to 150 chars, cf.
           // <http://moz.com/learn/seo/meta-description>
           // TODO move linebreak removal to backend?
-          meta: {
-            description: article.title + ' by ' + article.authors.join(', ') +
-              '.',
-            author: article.authors.join(', '),
-            keywords: article.tags.join(', ')
-          }
+          meta: [
+            {
+              name: 'description',
+              content: article.title + ' by ' + article.authors.join(', ') +
+                '.',
+            },
+            {name: 'author', content: article.authors.join(', ')},
+            {name: 'keywords', content: article.tags.join(', ')}
+          ]
         });
       })
       .error(function(data) {

--- a/src/js/controllers/articleSettings.js
+++ b/src/js/controllers/articleSettings.js
@@ -10,11 +10,14 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: 'Settings · ' + article.title + ' · PaperHive',
-            meta: {
-              description: 'Settings for ' + article.title + ' by ' +
-                article.authors.join(', '),
-              author: article.authors.join(', ')
-            }
+            meta: [
+              {
+                name: 'description',
+                content: 'Settings for ' + article.title + ' by ' +
+                  article.authors.join(', '),
+              },
+              {name: 'author', content: article.authors.join(', ')}
+            ]
           });
         }
       });

--- a/src/js/controllers/articleSettings.js
+++ b/src/js/controllers/articleSettings.js
@@ -10,9 +10,11 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: 'Settings · ' + article.title + ' · PaperHive',
-            author: article.authors.join(', '),
-            description:
-              article.abstract.replace(/(\r\n|\n|\r)/gm, ' ').substring(0, 150)
+            meta: {
+              description: 'Settings for ' + article.title + ' by ' +
+                article.authors.join(', '),
+              author: article.authors.join(', ')
+            }
           });
         }
       });

--- a/src/js/controllers/articleText.js
+++ b/src/js/controllers/articleText.js
@@ -25,7 +25,7 @@ module.exports = function(app) {
         if (article) {
           var description = 'Article with discussions.';
           if (discussions.length === 1) {
-            description =  'Article with 1 discusssion.';
+            description =  'Article with 1 discussion.';
           }
           if (discussions.length > 1) {
             description = 'Article with ' + discussions.length +

--- a/src/js/controllers/articleText.js
+++ b/src/js/controllers/articleText.js
@@ -37,10 +37,10 @@ module.exports = function(app) {
 
           metaService.set({
             title: article.title + ' · PaperHive',
-            meta: {
-              description: description,
-              author: article.authors.join(', ')
-            }
+            meta: [
+              {name: 'description', content: description},
+              {name: 'author', content: article.authors.join(', ')}
+            ]
           });
         }
       });

--- a/src/js/controllers/articleText.js
+++ b/src/js/controllers/articleText.js
@@ -23,9 +23,11 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: article.title + ' · PaperHive',
-            author: article.authors.join(', '),
-            description:
-              article.abstract.replace(/(\r\n|\n|\r)/gm, ' ').substring(0, 150),
+            meta: {
+              description: 'Annotations for ' + article.title + ' by ' +
+                article.authors.join(', '),
+              author: article.authors.join(', ')
+            }
           });
         }
       });

--- a/src/js/controllers/articleText.js
+++ b/src/js/controllers/articleText.js
@@ -19,13 +19,26 @@ module.exports = function(app) {
       };
 
       // set meta data
-      $scope.$watch('article', function(article) {
+      $scope.$watchGroup(['article', 'discussions.stored'], function(newVals) {
+        var article = newVals[0];
+        var discussions = newVals[1];
         if (article) {
+          var description = 'Article with discussions.';
+          if (discussions.length === 1) {
+            description =  'Article with 1 discusssion.';
+          }
+          if (discussions.length > 1) {
+            description = 'Article with ' + discussions.length +
+              ' discussions.';
+          }
+          description += (article.authors.length === 1 ?
+            ' Author: ' :
+            ' Authors: ') + article.authors.join(', ') + '.';
+
           metaService.set({
             title: article.title + ' · PaperHive',
             meta: {
-              description: 'Annotations for ' + article.title + ' by ' +
-                article.authors.join(', '),
+              description: description,
               author: article.authors.join(', ')
             }
           });

--- a/src/js/controllers/discussion.js
+++ b/src/js/controllers/discussion.js
@@ -25,14 +25,16 @@ module.exports = function(app) {
               ' · Discussion #' + discussion.index +
               ($scope.article ? (' · ' + $scope.article.title) : '') +
               ' · PaperHive',
-            author: discussion.originalAnnotation.author.displayName,
-            // TODO rather use title here?
-            description:
-              discussion.originalAnnotation.body ?
-              discussion.originalAnnotation.body.substring(0, 150) :
-              undefined,
-            keywords: discussion.originalAnnotation.tags ?
-              discussion.originalAnnotation.tags.join(', ') : undefined
+            meta: {
+              author: discussion.originalAnnotation.author.displayName,
+              // TODO rather use title here?
+              description: 'Annotation by ' +
+                discussion.originalAnnotation.author.displayName + ': ' +
+                (discussion.originalAnnotation.body ?
+                discussion.originalAnnotation.body.substring(0, 150) : ''),
+              keywords: discussion.originalAnnotation.tags ?
+                discussion.originalAnnotation.tags.join(', ') : undefined
+            }
           });
         })
         .error(notificationService.httpError('could not fetch discussion'));

--- a/src/js/controllers/discussion.js
+++ b/src/js/controllers/discussion.js
@@ -25,16 +25,25 @@ module.exports = function(app) {
               ' · Discussion #' + discussion.index +
               ($scope.article ? (' · ' + $scope.article.title) : '') +
               ' · PaperHive',
-            meta: {
-              author: discussion.originalAnnotation.author.displayName,
+            meta: [
+              {
+                name: 'author',
+                content: discussion.originalAnnotation.author.displayName
+              },
               // TODO rather use title here?
-              description: 'Annotation by ' +
-                discussion.originalAnnotation.author.displayName + ': ' +
-                (discussion.originalAnnotation.body ?
-                discussion.originalAnnotation.body.substring(0, 150) : ''),
-              keywords: discussion.originalAnnotation.tags ?
-                discussion.originalAnnotation.tags.join(', ') : undefined
-            }
+              {
+                name: 'description',
+                content: 'Annotation by ' +
+                  discussion.originalAnnotation.author.displayName + ': ' +
+                  (discussion.originalAnnotation.body ?
+                  discussion.originalAnnotation.body.substring(0, 150) : ''),
+              },
+              {
+                name: 'keywords',
+                content: discussion.originalAnnotation.tags ?
+                  discussion.originalAnnotation.tags.join(', ') : undefined
+              }
+            ]
           });
         })
         .error(notificationService.httpError('could not fetch discussion'));

--- a/src/js/controllers/discussionList.js
+++ b/src/js/controllers/discussionList.js
@@ -10,10 +10,13 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: 'Discussions · ' + article.title + ' · PaperHive',
-            meta: {
-              description: 'Discussions overview for ' + article.title +
-                ' by ' + article.authors.join(', ')
-            }
+            meta: [
+              {
+                name: 'description',
+                content: 'Discussions overview for ' + article.title +
+                  ' by ' + article.authors.join(', ')
+              }
+            ]
           });
         }
       });

--- a/src/js/controllers/discussionList.js
+++ b/src/js/controllers/discussionList.js
@@ -10,9 +10,10 @@ module.exports = function(app) {
         if (article) {
           metaService.set({
             title: 'Discussions · ' + article.title + ' · PaperHive',
-            author: article.authors.join(', '),
-            description:
-              article.abstract.replace(/(\r\n|\n|\r)/gm, ' ').substring(0, 150)
+            meta: {
+              description: 'Discussions overview for ' + article.title +
+                ' by ' + article.authors.join(', ')
+            }
           });
         }
       });

--- a/src/js/controllers/user.js
+++ b/src/js/controllers/user.js
@@ -21,11 +21,14 @@ module.exports = function(app) {
           metaService.set({
             title: data.username + ' (' + data.displayName + ')' +
               ' · PaperHive',
-            meta: {
-              description: 'Profile of ' + data.username +
-                ' (' + data.displayName + ')' +
-                ' on PaperHive.'
-            }
+            meta: [
+              {
+                name: 'description',
+                content: 'Profile of ' + data.username +
+                  ' (' + data.displayName + ')' +
+                  ' on PaperHive.'
+              }
+            ]
           });
         })
         .error(function(data) {

--- a/src/js/controllers/user.js
+++ b/src/js/controllers/user.js
@@ -21,6 +21,11 @@ module.exports = function(app) {
           metaService.set({
             title: data.username + ' (' + data.displayName + ')' +
               ' · PaperHive',
+            meta: {
+              description: 'Profile of ' + data.username +
+                ' (' + data.displayName + ')' +
+                ' on PaperHive.'
+            }
           });
         })
         .error(function(data) {


### PR DESCRIPTION
Note: the `description` meta tag is the only one that google respects, see [here](https://support.google.com/webmasters/answer/79812?hl=en). For example, `authors` and `keywords` are ignored. Instead, we should include appropriate opengraph/highwire/... tags.