### PR TITLE
[gulp] ship more mathjax files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,10 +155,9 @@ gulp.task('static', function () {
     'config/TeX-AMS_HTML-full.js',
     'config/Safe.js',
     'extensions/Safe.js',
-    'fonts/HTML-CSS/TeX/woff/*.woff',
+    'fonts/HTML-CSS/**/woff/*.woff',
     'jax/element/**',
-    'jax/output/HTML-CSS/autoload/**',
-    'jax/output/HTML-CSS/fonts/TeX/**'
+    'jax/output/HTML-CSS/**'
   ], function(path) {
     return mathjax_base + path;
   });


### PR DESCRIPTION
Check out the deployed [mathjax-blowup](https://paperhive.org/dev/frontend/branches/mathjax-blowup) branch. This should fix #167.