### PR TITLE
[gulp] disable gulp-sourcemaps temporarily

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,11 +75,11 @@ function js (watch) {
       .on('error', handleError)
       .pipe(source('index.js'))
       .pipe(buffer())
-      .pipe(sourcemaps.init({loadMaps: true}))
+      //.pipe(sourcemaps.init({loadMaps: true}))
         .pipe(debug ? gutil.noop() : streamify(uglify({
           preserveComments: 'some'
         })))
-      .pipe(sourcemaps.write('./'))
+      //.pipe(sourcemaps.write('./'))
       .pipe(gulp.dest('build'));
   }
   bundler.on('update', rebundle);


### PR DESCRIPTION
disable gulp-sourcemaps until floridoo/gulp-sourcemaps/issues/73 is resolved.