### PR TITLE
[html,js] add JSON-LD/schema.org organization to main page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,8 @@
     <!-- base href is the entry point of the deployed app -->
     <base href="<%= config.baseHref %>">
     <title data-ng-bind="metaService.data.title"></title>
+
+    <!-- meta tags -->
     <meta charset="utf-8">
     <meta name="language" content="en">
     <meta name="application-name" content="PaperHive">
@@ -13,6 +15,14 @@
       ng-repeat="meta in metaService.data.meta"
       name="{{meta.name}}" content="{{meta.content}}"
       >
+
+    <!-- JSON-LD -->
+    <script
+      ng-repeat="jsonld in metaService.data.jsonld"
+      ng-bind="jsonld | json"
+      type="application/ld+json">
+    </script>
+
     <!-- TODO: bundle mathjax in index.js -->
     <script src="assets/mathjax/MathJax.js?config=TeX-AMS_HTML-full,Safe">
     </script>

--- a/src/js/config/metaUpdate.js
+++ b/src/js/config/metaUpdate.js
@@ -12,7 +12,8 @@ module.exports = function(app) {
           $routeSegment.chain[$routeSegment.chain.length - 1].params;
         metaService.set({
           title: (params && params.title) || 'PaperHive',
-          meta: params && params.meta
+          meta: params && params.meta,
+          jsonld: params && params.jsonld
         });
       });
     }

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -43,6 +43,19 @@ module.exports = function(app) {
                 'together, on the spot and for free. Gain insight from the ' +
                 'findings of others.'
             }
+          ],
+          jsonld: [
+            {
+              '@context': 'http://schema.org',
+              '@type': 'Organization',
+              name: 'PaperHive',
+              url: 'https://paperhive.org',
+              sameAs: [
+                'https://plus.google.com/114787682678537396870',
+                'https://twitter.com/paper_hive',
+                'https://github.com/paperhive/',
+              ]
+            }
           ]
         })
         // 404 page not found

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -3,6 +3,18 @@ module.exports = function(app) {
   app.config([
     '$routeSegmentProvider', '$routeProvider',
     function($routeSegmentProvider, $routeProvider) {
+
+      // definition of metadata
+      var meta = {
+        main: {
+          title: 'PaperHive · Papers, alive.',
+          description: 'Review, discuss, and improve research articles – ' +
+            'together, on the spot and for free. Gain insight from the ' +
+            'findings of others.',
+          url: 'https://paperhive.org'
+        }
+      };
+
       $routeSegmentProvider
         .when('/', 'main')
         .when('/404', '404')
@@ -35,38 +47,23 @@ module.exports = function(app) {
         // Init Main Page
         .segment('main', {
           templateUrl: 'templates/main/main.html',
-          title: 'PaperHive · Papers, alive.',
+          title: meta.main.title,
           meta: [
-            {
-              name: 'description',
-              content: 'Review, discuss, and improve research articles – ' +
-                'together, on the spot and for free. Gain insight from the ' +
-                'findings of others.'
-            },
+            {name: 'description', content: meta.main.description},
             // open graph
             {property: 'og:type', content: 'website'},
-            {property: 'og:title', content: 'PaperHive · Papers, alive.'},
-            {
-              property: 'og:description',
-              content: 'Review, discuss, and improve research articles – ' +
-                'together, on the spot and for free. Gain insight from the ' +
-                'findings of others.'
-            },
+            {property: 'og:title', content: meta.main.title},
+            {property: 'og:description', content: meta.main.description},
             {
               property: 'og:image',
               content: 'https://paperhive.org/static/img/logo2.png'
             },
-            {property: 'og:url', content: 'https://paperhive.org'},
+            {property: 'og:url', content: meta.main.url},
             // twitter cards
             {name: 'twitter:card', content: 'summary'},
-            {name: 'twitter:url', content: 'https://paperhive.org'},
-            {name: 'twitter:title', content: 'PaperHive · Papers, alive.'},
-            {
-              name: 'twitter:description',
-              content: 'Review, discuss, and improve research articles – ' +
-                'together, on the spot and for free. Gain insight from the ' +
-                'findings of others.'
-            },
+            {name: 'twitter:url', content: meta.main.url},
+            {name: 'twitter:title', content: meta.main.title},
+            {name: 'twitter:description', content: meta.main.description},
             {
               name: 'twitter:image',
               content: 'https://paperhive.org/static/img/logo2.png'
@@ -77,7 +74,7 @@ module.exports = function(app) {
               '@context': 'http://schema.org',
               '@type': 'Organization',
               name: 'PaperHive',
-              url: 'https://paperhive.org',
+              url: meta.main.url,
               sameAs: [
                 'https://plus.google.com/114787682678537396870',
                 'https://twitter.com/paper_hive',

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -82,6 +82,7 @@ module.exports = function(app) {
                 'https://plus.google.com/114787682678537396870',
                 'https://twitter.com/paper_hive',
                 'https://github.com/paperhive/',
+                'https://www.youtube.com/channel/UCe4xC7kaff0ySd6yZuT2XYQ'
               ]
             }
           ]

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -42,7 +42,35 @@ module.exports = function(app) {
               content: 'Review, discuss, and improve research articles – ' +
                 'together, on the spot and for free. Gain insight from the ' +
                 'findings of others.'
-            }
+            },
+            // open graph
+            {property: 'og:type', content: 'website'},
+            {property: 'og:title', content: 'PaperHive · Papers, alive.'},
+            {
+              property: 'og:description',
+              content: 'Review, discuss, and improve research articles – ' +
+                'together, on the spot and for free. Gain insight from the ' +
+                'findings of others.'
+            },
+            {
+              property: 'og:image',
+              content: 'https://paperhive.org/static/img/logo2.png'
+            },
+            {property: 'og:url', content: 'https://paperhive.org'},
+            // twitter cards
+            {name: 'twitter:card', content: 'summary'},
+            {name: 'twitter:url', content: 'https://paperhive.org'},
+            {name: 'twitter:title', content: 'PaperHive · Papers, alive.'},
+            {
+              name: 'twitter:description',
+              content: 'Review, discuss, and improve research articles – ' +
+                'together, on the spot and for free. Gain insight from the ' +
+                'findings of others.'
+            },
+            {
+              name: 'twitter:image',
+              content: 'https://paperhive.org/static/img/logo2.png'
+            },
           ],
           jsonld: [
             {


### PR DESCRIPTION
This PR introduces the field `jsonld` to the `metaService` which can hold an array of JSON-LD objects. The objects are then injected as `<script>` tags in the `<head>` of the corresponding page.

Example usage: https://developers.google.com/structured-data/customize/social-profiles