### PR TITLE
Cache busters!

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,8 +90,9 @@ function js(watch) {
         .pipe(debug ? gutil.noop() : streamify(uglify({
           preserveComments: 'some'
         })))
-      //.pipe(sourcemaps.write('./'))
+      .pipe(cachebust.references())
       .pipe(cachebust.resources())
+      //.pipe(sourcemaps.write('./'))
       .pipe(gulp.dest('build'));
   }
   bundler.on('update', rebundle);
@@ -100,12 +101,12 @@ function js(watch) {
 }
 
 // bundle once
-gulp.task('js', ['templates'], function() {
+gulp.task('js', ['templates', 'vendor'], function() {
   return js(false);
 });
 
 // bundle with watch
-gulp.task('js:watch', ['templates'], function() {
+gulp.task('js:watch', ['templates', 'vendor'], function() {
   return js(true);
 });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,8 +15,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'build/assets/mathjax/MathJax.js',
-      'build/index.js',
+      'build/assets/mathjax.*/MathJax.js',
+      'build/index.*.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'test/karma/**/*.js'
     ],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gulp": "3.9.0",
     "gulp-angular-templatecache": "1.8.0",
     "gulp-batch": "1.0.5",
+    "gulp-cachebust": "0.0.6",
     "gulp-connect": "2.2.0",
     "gulp-eslint": "1.0.0",
     "gulp-htmlhint": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "browserify-shim": "3.8.10",
     "connect-history-api-fallback": "1.1.0",
     "del": "2.0.2",
+    "fs": "0.0.2",
     "gulp": "3.9.0",
     "gulp-angular-templatecache": "1.8.0",
     "gulp-batch": "1.0.5",

--- a/src/index.html
+++ b/src/index.html
@@ -42,7 +42,7 @@
     </script>
 
     <!-- TODO: bundle mathjax in index.js -->
-    <script src="assets/mathjax/MathJax.js?config=TeX-AMS_HTML-full,Safe">
+    <script src="<%= mathjaxDir %>/MathJax.js?config=TeX-AMS_HTML-full,Safe">
     </script>
 
     <link href="index.css" rel="stylesheet">


### PR DESCRIPTION
![gb](https://cloud.githubusercontent.com/assets/181628/10745926/1fa2252e-7c46-11e5-80ba-51f58bb18b8d.gif)

This PR implements cache busting with [gulp-cachebust](https://www.npmjs.com/package/gulp-cachebust) and -- since MathJax isn't working for it -- some small additions here and there for directory-based cache busting for `assets/mathjax/`.