### PR TITLE
use smaller headings on xs-devices

### DIFF
--- a/src/less/bootstrap/index.less
+++ b/src/less/bootstrap/index.less
@@ -3,6 +3,7 @@
 
 // overwrite bootstrap variables
 // see http://stackoverflow.com/a/19514889/1219479
+@import "type.less";
 @import "variables.less";
 
 // set font path

--- a/src/less/bootstrap/type.less
+++ b/src/less/bootstrap/type.less
@@ -1,0 +1,5 @@
+@media (max-width: @screen-xs-max) {
+  h1, .h1 { font-size: @font-size-xs-h1; }
+  h2, .h2 { font-size: @font-size-xs-h2; }
+  h3, .h3 { font-size: @font-size-xs-h3; }
+}

--- a/src/less/bootstrap/variables.less
+++ b/src/less/bootstrap/variables.less
@@ -9,6 +9,11 @@
 @font-family-sans-serif: Roboto, sans-serif;
 @blockquote-border-color: lighten(@ph-highlight-color, 50%);
 
+// use slightly smaller headings on xs devices
+@font-size-xs-h1: floor((@font-size-base * 2.1));
+@font-size-xs-h2: floor((@font-size-base * 1.8));
+@font-size-xs-h3: ceil((@font-size-base * 1.5));
+
 /* Iconography */
 
 /* Components */


### PR DESCRIPTION
fixes overflow on iphone.

This PR is identical to paperhive/paperhive-launch/pull/6.