### PR TITLE
fix footer bg and padding

### DIFF
--- a/less/paperhive/footer.less
+++ b/less/paperhive/footer.less
@@ -27,7 +27,7 @@ body {
 .ph-footer {
   background-color: @gray;
   color: @body-bg;
-  padding-top: @padding-large-horizontal;
+  padding-top: 2 * @padding-large-horizontal;
   padding-bottom: @padding-large-horizontal;
 
   // copyright
@@ -46,6 +46,7 @@ body {
 }
 
 .ph-footer-supporters {
+  background-color: #fff;
   padding-top: @padding-large-horizontal;
   padding-bottom: @padding-large-horizontal;
 


### PR DESCRIPTION
On small screens the footer showed a few pixels of the video. This is fixed by setting a background color.