### PR TITLE
disable autocompletion in the search field

### DIFF
--- a/html/shared/navbar.html
+++ b/html/shared/navbar.html
@@ -40,6 +40,7 @@
               typeahead-template-url="html/shared/navbarSearchItem.html"
               ng-keypress="($event.which === 13) && showAllResults(search.body)"
               typeahead-focus-first="false"
+              autocomplete="off"
               required
               >
           </div>


### PR DESCRIPTION
* Fixes #334
* Just setting the autocomplete attribute to false works in Chrome and Chromium
* I couldn't reproduce the issue in Firefox