### PR TITLE
Fix jenkins badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # PaperHive Frontend
 
-[![Build Status](https://jenkins.paperhive.org/buildStatus/icon?job=frontend-staging)](https://jenkins.paperhive.org/job/frontend-staging/)
+[![Build Status](https://jenkins.paperhive.org/buildStatus/icon?job=frontend)](https://jenkins.paperhive.org/job/frontend/)
 [![Dependency Status](https://gemnasium.com/paperhive/paperhive-frontend.svg)](https://gemnasium.com/paperhive/paperhive-frontend)
-
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/nschloe.svg)](https://saucelabs.com/u/nschloe)
 
 ---


### PR DESCRIPTION
The saucelabs badge is still broken. I don't know how to fix this – the badge also shows "unknown" on https://saucelabs.com/u/nschloe.