### PR TITLE
fix whitespace trimming

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ var paths = {
 
 var htmlminOpts = {
   collapseWhitespace: true,
+  conservativeCollapse: true,
   removeComments: true
 };
 


### PR DESCRIPTION
The whitespace bug observed in #388 is caused by [html-minifier](https://github.com/kangax/html-minifier) 1.3.0.

This PR fixes the issue.