### PR TITLE
Documents without access

### DIFF
--- a/app/components/document/index.ts
+++ b/app/components/document/index.ts
@@ -117,25 +117,25 @@ export default function(app) {
           )
           .success(function(ret) {
             $scope.revisions = ret.revisions;
-            $scope.latestOAIdx = findLastIndex(ret.revisions, {isOpenAccess: true});
 
-            const latestOARevision = $scope.revisions[$scope.latestOAIdx];
+            const latestRevision = $scope.revisions[$scope.revisions.length - 1];
             // Cut description down to 150 chars, cf.
             // <http://moz.com/learn/seo/meta-description>
             // TODO move linebreak removal to backend?
             const metaData = [
               {
                 name: 'description',
-                content: latestOARevision.title + ' by ' + latestOARevision.authors.join(', ') + '.'
+                content: latestRevision.title + ' by ' + latestRevision.authors.join(', ') + '.'
               },
-              {name: 'author', content: latestOARevision.authors.join(', ')},
-              {name: 'keywords', content: latestOARevision.tags.join(', ')}
+              {name: 'author', content: latestRevision.authors.join(', ')},
+              {name: 'keywords', content: latestRevision.tags.join(', ')}
             ];
-
             $scope.addDocumentMetaData(metaData);
 
+            $scope.latestOAIdx = findLastIndex(ret.revisions, {isOpenAccess: true});
+
             metaService.set({
-              title: latestOARevision.title + ' · PaperHive',
+              title: latestRevision.title + ' · PaperHive',
               meta: metaData
             });
           })

--- a/app/components/document/template.html
+++ b/app/components/document/template.html
@@ -3,9 +3,9 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-sm-10">
-          <h2 class="ph-lg-margin-top">{{revisions[latestOAIdx].title}}</h2>
+          <h2 class="ph-lg-margin-top">{{revisions[revisions.length - 1].title}}</h2>
           <h4 class="ph-lg-margin-bottom">
-            <span ng-repeat="author in revisions[latestOAIdx].authors">
+            <span ng-repeat="author in revisions[revisions.length - 1].authors">
               {{author.name}}{{$last ? '' :', '}}
             </span>
           </h4>

--- a/app/controllers/documentText.ts
+++ b/app/controllers/documentText.ts
@@ -13,7 +13,6 @@ export default function(app) {
       authService, notificationService, distangleService, metaService, tourService,
       smoothScroll
     ) {
-
       $scope.tour = tourService;
 
       $scope.text = {
@@ -75,8 +74,10 @@ export default function(app) {
             });
           }
         } else {
-          // default to the latest OA revision
-          activeRevisionIdx = $scope.latestOAIdx;
+          // Default to the latest OA revision, and -- if that's not available
+          // -- the latest revision.
+          activeRevisionIdx =
+            $scope.latestOAIdx !== -1 ? $scope.latestOAIdx : revisions.length - 1;
         }
         // Expose in scope
         $scope.activeRevisionIdx = activeRevisionIdx;

--- a/app/controllers/documentText.ts
+++ b/app/controllers/documentText.ts
@@ -37,9 +37,9 @@ export default function(app) {
 
       function getPdfUrl(documentRevision) {
         if (documentRevision.file.hasCors &&
-            urlPackage.parse(documentRevision.file.url).protocol === 'https') {
+            urlPackage.parse(documentRevision.file.url).protocol === 'https:') {
           // all good
-          return documentRevision.file;
+          return documentRevision.file.url;
         }
         // No HTTPS/Cors? PaperHive can proxy the document if it's open access.
         if (documentRevision.isOpenAccess) {

--- a/app/controllers/documentText.ts
+++ b/app/controllers/documentText.ts
@@ -89,6 +89,8 @@ export default function(app) {
               `/documents/${latestOaRevision.id}/revisions/${latestOaRevision.revision}`
             );
             // TODO display a notification about the redirect?
+            // Problem: $routeChangeSuccess wipes the notifications and it
+            // triggered *right after* $locationChangeSuccess.
           } else {
             notificationService.notifications.push({
               type: 'error',

--- a/config.json.default
+++ b/config.json.default
@@ -1,5 +1,9 @@
 {
   "apiUrl": "https://dev.paperhive.org/backend/master",
   "apiVersion": "1.0.0",
-  "baseHref": "/"
+  "baseHref": "/",
+  "elsevier": {
+    "entitlementApiUrl": "https://api.elsevier.com/content/article/entitlement/doi",
+    "apiKey": "d7cd85afb9582a3d0862eb536dac32b0"
+  }
 }


### PR DESCRIPTION
If the user has no access to a specifically selected revision, redirect to the latest OA revision (if any). In case there is no accessible version, display an error message.

Fixes bugs #340 and #409.