### PR TITLE
minor bug fixes

### DIFF
--- a/app/components/navbar-user/template.html
+++ b/app/components/navbar-user/template.html
@@ -36,11 +36,6 @@
         </a>
       </li>
       <li>
-        <a href="./documents/new">
-          <i class="fa fa-fw fa-plus"></i> Add arXiv article
-        </a>
-      </li>
-      <li>
         <a href="./settings">
           <i class="fa fa-fw fa-cog"></i> Settings
         </a>

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -661,8 +661,6 @@ export default function(app) {
               return selectors;
             }));
 
-            selection.removeAllRanges();
-
             return this.onSelect(selectors);
           });
         });

--- a/less/paperhive/pdf.less
+++ b/less/paperhive/pdf.less
@@ -34,6 +34,10 @@ pdf-full {
      * <https://github.com/mozilla/pdf.js/issues/6614> */
     line-height: 1.0;
 
+    // allow text selections
+    .ph-selection(text);
+
+    // style text selections
     & ::selection {
       background: @ph-highlight-color;
     }
@@ -52,8 +56,6 @@ pdf-full {
       -ms-transform-origin: 0% 0%;
       transform-origin: 0% 0%;
       z-index: 1000;
-      // allow text selections
-      .ph-selection(text);
     }
   }
 


### PR DESCRIPTION
* disable 'add arxiv article'
* do not remove selection after computing the text selectors: re-allows copying of text
* allow text selections on pdf-text layer (and not only on its children): fixes text deselect issue