### PR TITLE
fix SecurityError with disabled cookies/localStorage

### DIFF
--- a/app/components/navbar/index.ts
+++ b/app/components/navbar/index.ts
@@ -6,18 +6,12 @@ export default function(app) {
   app.component(
     'navbar', {
       template,
-      controller : ['$routeSegment', '$scope', '$window', 'tourService',
-          function($routeSegment, $scope, $window, tourService) {
+      controller : ['$routeSegment', '$scope', 'tourService',
+          function($routeSegment, $scope, tourService) {
         $scope.collapsed = true;
 
         $scope.tour = tourService;
         $scope.$routeSegment = $routeSegment;
-
-        // ask local storage if flag 'tourVisited' is already set
-        if ($window.localStorage.tourVisited) {
-          $scope.tourVisited = true;
-        }
-
       }]
     });
 };

--- a/app/components/navbar/template.html
+++ b/app/components/navbar/template.html
@@ -8,7 +8,7 @@
     <div
       class="navbar-header"
       popover-placement="bottom-left"
-      popover-is-open="tour.stages[tour.index] === 'start' && !tourVisited && $routeSegment.name !== 'main'"
+      popover-is-open="tour.stages[tour.index] === 'start' && !tour.visited && $routeSegment.name !== 'main'"
       uib-popover-template="'html/shared/tour-start.html'"
       popover-trigger="none"
     >

--- a/app/services/auth.ts
+++ b/app/services/auth.ts
@@ -1,4 +1,7 @@
 'use strict';
+
+import {localStorageAvailable} from '../utils/localStorage';
+
 export default function(app) {
   app.factory('authService', ['config', '$http', '$q', '$rootScope', '$window', '$location',
     function(config, $http, $q, $rootScope, $window, $location) {
@@ -79,7 +82,9 @@ export default function(app) {
             authService.token = data.token;
 
             // fires 'storage' event in other tabs
-            $window.localStorage.token = data.token;
+            if (localStorageAvailable) {
+              $window.localStorage.token = data.token;
+            }
 
             // use token for all subsequent HTTP requests to API
             $http.defaults.headers.common['Authorization'] = 'token ' + data.token;
@@ -141,7 +146,9 @@ export default function(app) {
 
       // sign out and forget token
       authService.logout = function() {
-        delete $window.localStorage.token;
+        if (localStorageAvailable) {
+          delete $window.localStorage.token;
+        }
         delete $http.defaults.headers['Authorization'];
         delete authService.user;
         delete authService.token;
@@ -167,9 +174,11 @@ export default function(app) {
         $rootScope.$apply();
       });
 
-      // set token from local storage when initializing (if available)
-      if ($window.localStorage.token) {
-        authService.loginToken($window.localStorage.token);
+      if (localStorageAvailable) {
+        // set token from local storage when initializing (if available)
+        if ($window.localStorage.token) {
+          authService.loginToken($window.localStorage.token);
+        }
       }
 
       return authService;

--- a/app/services/tour.ts
+++ b/app/services/tour.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import {localStorageAvailable} from '../utils/localStorage';
+
 export default function(app) {
   app.factory(
     'tourService',
@@ -15,24 +17,36 @@ export default function(app) {
             'signup'
           ],
           index: 0,
+          visited: false,
         };
+
+        // get tourVisited from localStorage
+        if (localStorageAvailable) {
+          service.visited = $window.localStorage.tourVisited;
+        }
 
         service.increaseIndex = function() {
           service.index++;
 
           // do not show the tour next time when the last stage has been reached
-          if (service.index === service.stages.length - 1) {
-            $window.localStorage.tourVisited = true;
-          }
-
-          if (authService.user && (service.index === service.stages.length - 2)) {
-            $window.localStorage.tourVisited = true;
+          if (service.index === service.stages.length - 1 ||
+              authService.user && (service.index === service.stages.length - 2)
+              ) {
+            service.visited = true;
+            if (localStorageAvailable) {
+              $window.localStorage.tourVisited = true;
+            }
           }
         };
 
         // begin with margin discussion
         service.start = function () {
-          $window.localStorage.tourVisited = false;
+          // reset visited flag
+          service.visited = false;
+          if (localStorageAvailable) {
+            $window.localStorage.tourVisited = false;
+          }
+
           service.index = 1;
           $location.url('/documents/0tsHJq1-yyVZ');
         };
@@ -42,11 +56,11 @@ export default function(app) {
         };
 
         service.reject = function() {
-          // ask local storage if flag 'tourVisited' is already set
-          if (!$window.localStorage.tourVisited) {
-            // set flag at first usage
+          service.visited = true;
+          if (localStorageAvailable) {
             $window.localStorage.tourVisited = true;
           }
+
           service.index = undefined;
         };
 

--- a/app/utils/localStorage.ts
+++ b/app/utils/localStorage.ts
@@ -1,0 +1,9 @@
+// Test localStorage availability
+// it may be missing or access is forbidden due to the cookies settings
+// (for example in Firefox)
+export let localStorageAvailable = false;
+try {
+  if (window.localStorage) localStorageAvailable = true;
+} catch (err) {
+  if (err.name !== 'SecurityError') throw err;
+}


### PR DESCRIPTION
Firefox with cookie policy "ask me every time" leads to a `SecurityError` when `localStorage` is used (verified with Firefox 38). This PR introduces a check for localStorage availability. 

Thanks to Michael Rothgang for reporting the issue!