### PR TITLE
Fix strict DI

### DIFF
--- a/app/components/new-reply/index.ts
+++ b/app/components/new-reply/index.ts
@@ -5,7 +5,7 @@ class NewReplyCtrl {
   body: string;
   submitting: boolean;
 
-  $inject = ['$q'];
+  static $inject = ['$q'];
   constructor(public $q) {}
 
   submit() {

--- a/app/index.ts
+++ b/app/index.ts
@@ -71,4 +71,4 @@ filters(paperhive);
 services(paperhive);
 utils(paperhive);
 
-angular.bootstrap(document, ['paperhive']);
+angular.bootstrap(document, ['paperhive'], {strictDi: true});


### PR DESCRIPTION
New replies in the thread view failed in non-dev-mode due to a broken `$inject` property. This PR fixes the issue and re-enables strict dependency injection mode.

Thanks to Lisa Matthias for finding this bug (and sorry for the lost reply!). :grin: 