### PR TITLE
Use pii for Elsevier entitlement check and extract apiKey from file url

### DIFF
--- a/app/components/document-text.ts
+++ b/app/components/document-text.ts
@@ -122,15 +122,15 @@ class DocumentTextCtrl {
     }
     try {
       if (revision.remote.type === 'elsevier') {
+        // extract apiKey from file.url
+        const parsedUrl = urlParse(revision.file.url, true);
+        const apiKey = parsedUrl.query.apiKey;
+
+        const id = revision.pii ? `pii/${revision.pii}` : `doi/${revision.doi}`;
+
         const result = await this.$http.get(
-          `https://api.elsevier.com/content/article/entitlement/doi/${revision.doi}`,
-          {
-            params: {
-              // TODO: use apiKey from config.json
-              apiKey: 'd7cd85afb9582a3d0862eb536dac32b0',
-              httpAccept: 'application/json',
-            }
-          }
+          `https://api.elsevier.com/content/article/entitlement/${id}`,
+          {params: {apiKey, httpAccept: 'application/json'}}
         );
         if (get(result, 'data.entitlement-response.document-entitlement.entitled')) {
           return true;


### PR DESCRIPTION
 * use pii instead of doi for Elsevier entitlement checks. This fixes issues with non-accessible Elsevier articles. The Elsevier API incorrectly treats dois as case sensitive; with this PR we prefer the unambiguous pii.
 * extract the Elsevier apiKey from the revision's `file.url`