### PR TITLE
Use JSPM bundle in watch

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -88,6 +88,7 @@ NOTE: ng-app is removed because angular is loaded asynchronously via
       <script src="jspm_packages/system.js"></script>
       <script src="jspm.browser.js"></script>
       <script src="jspm.config.js"></script>
+      <script src="build-dev/bundle.js"></script>
       <script>
         System.import('app/index.ts').then(undefined, console.error.bind(console));
       </script>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch:css": "nodemon -C -e less -w less -x \"npm run build:dev:css\"",
     "watch:html": "nodemon -C -e html -w html -x \"npm run build:dev:html\"",
     "watch:index": "nodemon -C -e html -w index.template.html -x \"npm run build:dev:index\"",
-    "watch:js": "jspm bundle app/index.ts build-dev/bundle.js -wid",
+    "watch:js": "jspm bundle app/index.ts build-dev/bundle.js -wd",
     "watch:serve": "live-server --no-browser --wait=50 --watch=build-dev  --mount=/:build-dev --entry-file=build-dev/index.html"
   },
   "author": "André Gaul <andre@paperhive.org>",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "watch:css": "nodemon -C -e less -w less -x \"npm run build:dev:css\"",
     "watch:html": "nodemon -C -e html -w html -x \"npm run build:dev:html\"",
     "watch:index": "nodemon -C -e html -w index.template.html -x \"npm run build:dev:index\"",
-    "watch:serve": "live-server --no-browser --wait=250 --watch=app --watch=jspm_packages --watch=build-dev --watch=build-tmp --mount=/:build-dev --entry-file=build-dev/index.html"
+    "watch:js": "jspm bundle app/index.ts build-dev/bundle.js -wid",
+    "watch:serve": "live-server --no-browser --wait=50 --watch=build-dev  --mount=/:build-dev --entry-file=build-dev/index.html"
   },
   "author": "André Gaul <andre@paperhive.org>",
   "license": "GPL-3.0",


### PR DESCRIPTION
Use `jspm bundle` with watch functionality for speeding up the page load in the dev environment. No more >300 HTTP requests!

This reduces the page load from >15s to ~5s on my machine.