### PR TITLE
pdf: prevent overflow on pdf-text div

### DIFF
--- a/less/paperhive/pdf.less
+++ b/less/paperhive/pdf.less
@@ -14,6 +14,7 @@ pdf-full {
   .ph-selection(none);
 
   & > .ph-pdf-text {
+    overflow: hidden;
     position: absolute;
     left: 0;
     top: 0;


### PR DESCRIPTION
This PR fixes issues with PDF pages that contain text outside the page's boundary box.

Thanks to Nikola Chernev for reporting the issue.