### PR TITLE
fix discussion rendering at position 0

### DIFF
--- a/app/components/margin-discussions.ts
+++ b/app/components/margin-discussions.ts
@@ -43,7 +43,7 @@ export default function(app) {
             return discussionIds.filter(discussionId => {
               const position = $ctrl.discussionPositions[discussionId];
               const size = $ctrl.discussionSizes[discussionId];
-              if (!position || !size) return false;
+              if (position === undefined || size === undefined) return false;
               return parentTop + position + size.height > - viewportHeight && parentTop + position < 2 * viewportHeight;
             });
           }


### PR DESCRIPTION
fixes an issue where the topmost discussion was not properly rendered:

![screenshot from 2016-09-28 12-54-36](https://cloud.githubusercontent.com/assets/1874116/18910986/caeb34aa-857a-11e6-8472-424c5d8638b6.png)

(see https://paperhive.org/documents/0tsHJq1-yyVZ)