### PR TITLE
Add support for links in PDFs

### DIFF
--- a/app/components/document-text.html
+++ b/app/components/document-text.html
@@ -102,6 +102,7 @@
         on-all-pages-resized="$ctrl.allPagesInitialized = true"
         on-select="$ctrl.draftSelectors = selectors || $ctrl.draftSelectors"
         on-link-dest-create="$ctrl.getLinkDest(dest)"
+        on-anchor-update="$ctrl.updateAnchor(anchor)"
 
         popover-placement="top"
         popover-is-open="$ctrl.tourService.stages[$ctrl.tourService.index] === 'highlight'"

--- a/app/components/document-text.html
+++ b/app/components/document-text.html
@@ -102,7 +102,7 @@
         on-all-pages-resized="$ctrl.allPagesInitialized = true"
         on-select="$ctrl.draftSelectors = selectors || $ctrl.draftSelectors"
         on-link-dest-create="$ctrl.getLinkDest(dest)"
-        on-anchor-update="$ctrl.updateAnchor(anchor)"
+        on-anchor-update="$ctrl.anchor = anchor"
 
         popover-placement="top"
         popover-is-open="$ctrl.tourService.stages[$ctrl.tourService.index] === 'highlight'"

--- a/app/components/document-text.ts
+++ b/app/components/document-text.ts
@@ -67,7 +67,7 @@ class DocumentTextCtrl {
         {documentId: this.activeRevision.id} :
         {documentId: this.activeRevision.id, revisionId: this.activeRevision.revision}
     );
-    return `.${baseUrl}#pdfdest:${encodeURIComponent(dest)}`;
+    return `.${baseUrl}?a=pdfd:${encodeURIComponent(dest)}`;
   }
 
   getNewDiscussion(discussion) {

--- a/app/components/document-text.ts
+++ b/app/components/document-text.ts
@@ -38,8 +38,9 @@ class DocumentTextCtrl {
     $scope.$watch('$ctrl.draftSelectors', this.updateHighlights.bind(this));
 
     // update and watch anchor and query parameter
-    this.updateAnchor();
-    $scope.$on('$routeUpdate', () => this.updateAnchor());
+    this.updateAnchorFromUrl();
+    $scope.$on('$routeUpdate', () => this.updateAnchorFromUrl());
+    $scope.$watch('$ctrl.anchor', anchor => this.updateAnchorToUrl(anchor));
   }
 
   getAccessiblePdfUrl(revision) {
@@ -61,12 +62,8 @@ class DocumentTextCtrl {
   // create link for pdf destinations
   getLinkDest(dest) {
     const segmentName = this.$routeSegment.name;
-    const baseUrl = this.$routeSegment.getSegmentUrl(
-      segmentName,
-      segmentName === 'documents.text' ?
-        {documentId: this.activeRevision.id} :
-        {documentId: this.activeRevision.id, revisionId: this.activeRevision.revision}
-    );
+    const baseUrl = this.$routeSegment
+      .getSegmentUrl(segmentName, this.$routeSegment.$routeParams);
     return `.${baseUrl}?a=pdfd:${encodeURIComponent(dest)}`;
   }
 
@@ -205,16 +202,17 @@ class DocumentTextCtrl {
 
   // note: a query parameter is used because a fragment identifier (hash)
   //       is *not* part of the URL.
-  updateAnchor() {
-    // transform fragment identifier (hash) into a query parameter
-    let hash = this.$location.hash();
-    if (hash) {
-      this.$location.hash('');
-      this.$location.search({a: hash});
-    }
+  updateAnchorFromUrl() {
+    // get anchor from hash or search param
+    const anchor = this.$location.hash() || this.$location.search().a;
+    // reset hash
+    this.$location.hash('');
+    // update anchor
+    this.anchor = anchor;
+  }
 
-    // use query parameter 'a' as anchor
-    this.anchor = this.$location.search().a;
+  updateAnchorToUrl(anchor) {
+    this.$location.search({a: anchor});
   }
 
   // generate highlights array

--- a/app/config/routes.ts
+++ b/app/config/routes.ts
@@ -39,7 +39,7 @@ export default function(app) {
         .when('/documents/:documentId/discussions/:discussionId',
               'documents.discussions.thread')
         .when('/documents/:documentId/text', 'documents.text', {reloadOnSearch: false})
-        .when('/documents/:documentId/revisions/:revisionId', 'documents.revisions')
+        .when('/documents/:documentId/revisions/:revisionId', 'documents.revisions', {reloadOnSearch: false})
         .when('/documents/:documentId/about', 'documents.about')
         .when('/contact', 'contact')
         .when('/help/markdown', 'helpMarkdown')

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -237,7 +237,7 @@ export default function(app) {
       }
     }
 
-    // TODO: implement!
+    // a pdfjs-compliant linkService
     class LinkService {
       constructor(public onLinkCreate, public scrollToAnchor) {}
 
@@ -1075,8 +1075,6 @@ export default function(app) {
 
         // called when the anchor is updated
         onAnchorUpdate: '&',
-
-        // TODO: scroll interface
       },
       link: async function(scope, element, attrs) {
         let pdfFull;

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -286,60 +286,6 @@ export default function(app) {
           page: this.page,
           viewport: viewport,
         });
-
-        /*
-        this.element.find('a').on('mouseenter', event => event.stopPropagation());
-
-        // forward mouse events to underlying layer
-        ['mouseenter', 'mouseover', 'mousemove', 'mousedown', 'mouseup', 'click', 'dblclick', 'mouseleave', 'mouseout', 'select'].forEach(type => {
-          this.element[0].addEventListener(type, (event) => {
-            console.log(event.type, event);
-
-            this.element.hide();
-            const el = document.elementFromPoint(event.clientX, event.clientY);
-            this.element.show();
-            if (!el) return true;
-
-            const newEventOptions = pick(event,
-              // MouseEvent properties
-              'screenX', 'screenY', 'clientX', 'clientY',
-              'ctrlKey', 'shiftKey', 'altKey', 'metaKey', 'button', 'buttons',
-              'relatedTarget', 'region',
-              // UIEvent properties
-              'detail', 'view', 'sourceCapabilities',
-              // Event properties
-              'bubbles', 'cancelable', 'scoped'
-            );
-            const newEvent = new MouseEvent(event.type, newEventOptions);
-            jquery(el).select();
-            el.dispatchEvent(newEvent);
-
-            // this.element.css({'pointer-events': 'all'});
-
-            event.preventDefault();
-            event.stopPropagation();
-          }, true);
-        });
-        */
-
-        /*
-        this.element.on('mousedown mousemove mouseup click', (event) => {
-          this.element.hide();
-          const el = document.elementFromPoint(event.clientX, event.clientY);
-          this.element.show();
-          if (!el) return true;
-
-          const eventOpts = pick(event, 'bubbles', 'cancelable',
-            'screenX', 'screenY', 'clientX', 'clientY', 'movementX', 'movementY',
-            'ctrlKey', 'shiftKey', 'altKey', 'metaKey', 'button', 'buttons');
-          jquery(el).trigger(event.type, eventOpts);
-
-          event.preventDefault();
-          event.stopPropagation();
-
-          return false;
-        });
-        */
       }
     }
 
@@ -624,6 +570,7 @@ export default function(app) {
         angular.element($window).on('resize', _render);
         angular.element($window).on('scroll', _render);
 
+        // focus text layer on mousedown (except click on links)
         let mousedown = false;
         this.element.on('mousedown', event => {
           if (jquery(event.target).prop('tagName') === 'A') return;
@@ -637,11 +584,10 @@ export default function(app) {
         };
         $document.on('mouseup', onMouseUp);
 
-        // focus text layer on drag and ctrl+alt
+        // focus text layer while ctrl+alt is pressed
         // note: key events are not fired on PDFs
         const onKeyEvent = event => {
           const ctrlAlt = event.altKey && event.ctrlKey;
-          console.log(event);
           if (ctrlAlt) this.textFocus();
           else if (!mousedown) {
             this.textUnfocus();

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -533,14 +533,14 @@ export default function(app) {
       textFocus() {
         this.textFocused = true;
         if (this.initializedRenderers) {
-          this.textRenderer.element.insertAfter(this.annotationsRenderer.element);
+          this.annotationsRenderer.element.addClass('ph-no-interaction');
         }
       }
 
       textUnfocus() {
         this.textFocused = false;
         if (this.initializedRenderers) {
-          this.textRenderer.element.insertBefore(this.annotationsRenderer.element);
+          this.annotationsRenderer.element.removeClass('ph-no-interaction');
         }
       }
 
@@ -624,8 +624,14 @@ export default function(app) {
         angular.element($window).on('resize', _render);
         angular.element($window).on('scroll', _render);
 
-        // detect text selections
-        const _onTextSelect = this.onTextSelect.bind(this);
+        // focus text layer on drag
+        this.element.on('mousedown', () => this.textFocus());
+
+        // unfocus text layer and detect text selections
+        const _onTextSelect = () => {
+          this.textUnfocus();
+          this.onTextSelect();
+        };
         $document.on('mouseup keyup', _onTextSelect); // key events are not fired on PDFs
 
         // unregister event handlers
@@ -634,6 +640,9 @@ export default function(app) {
           angular.element($window).off('scroll', _render);
           $document.off('mouseup keyup', _onTextSelect);
         });
+
+
+        this.element.on('mouseup', () => this.textUnfocus());
 
         // render at least once
         this.render();
@@ -958,11 +967,13 @@ export default function(app) {
       }
 
       textFocus() {
+        if (this.textFocused) return;
         this.textFocused = true;
         this.pages.forEach(page => page.textFocus());
       }
 
       textUnfocus() {
+        if (!this.textFocused) return;
         this.textFocused = false;
         this.pages.forEach(page => page.textUnfocus());
       }

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -624,8 +624,21 @@ export default function(app) {
         angular.element($window).on('resize', _render);
         angular.element($window).on('scroll', _render);
 
-        // focus text layer on drag
-        this.element.on('mousedown', () => this.textFocus());
+
+        // this.element.on('mousedown', () => this.textFocus());
+
+        // focus text layer on drag and ctrl+alt
+        const onTextFocus = (event) => {
+          if (event.type === 'mousedown' && jquery(event.target).prop('tagName') !== 'A') {
+            this.textFocus();
+            return;
+          }
+          const ctrlAlt = event.altKey && event.ctrlKey;
+          if (ctrlAlt) this.textFocus();
+          else this.textUnfocus;
+        };
+        $document.on('keydown keyup', onTextFocus);
+        this.element.on('mousedown', onTextFocus);
 
         // unfocus text layer and detect text selections
         const _onTextSelect = () => {
@@ -638,6 +651,7 @@ export default function(app) {
         this.element.on('$destroy', () => {
           angular.element($window).off('resize', _render);
           angular.element($window).off('scroll', _render);
+          $document.off('keydown keyup', onTextFocus);
           $document.off('mouseup keyup', _onTextSelect);
         });
 

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -296,7 +296,7 @@ export default function(app) {
             `<div class="tooltip top fade" role="tooltip">
               <div class="tooltip-arrow"></div>
               <div class="tooltip-inner">
-                Press and hold CTRL+ALT to select text inside a link.
+                Press and hold Ctrl+Alt to select text inside a link.
               </div>
             </div>`
           );

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -256,6 +256,7 @@ export default function(app) {
       linkService: any;
       page: PDFPageProxy;
       annotations: PDFAnnotations;
+      tooltip: JQuery;
 
       constructor(element, page, linkService) {
         this.page = page;
@@ -285,6 +286,36 @@ export default function(app) {
           linkService: this.linkService,
           page: this.page,
           viewport: viewport,
+        });
+
+        // create tooltip
+        // TODO: use angular here?
+        this.element.find('section').on('dragstart', event => {
+          if (this.tooltip) this.tooltip.remove();
+          this.tooltip = jquery(
+            `<div class="tooltip top fade" role="tooltip">
+              <div class="tooltip-arrow"></div>
+              <div class="tooltip-inner">
+                Press and hold CTRL+ALT to select text inside a link.
+              </div>
+            </div>`
+          );
+          this.tooltip.appendTo(this.element);
+          const target = jquery(event.currentTarget);
+          const position = target.position();
+          this.tooltip.css({
+            top: position.top - this.tooltip.height() - 8,
+            left: position.left + target.width() / 2 - this.tooltip.width() / 2,
+          });
+          setTimeout(() => this.tooltip.addClass('in'), 0);
+        });
+        this.element.find('a').on('dragend', event => {
+          if (this.tooltip) {
+            const tooltip = this.tooltip;
+            this.tooltip = undefined;
+            tooltip.removeClass('in');
+            setTimeout(() => tooltip.remove(), 500);
+          }
         });
       }
     }

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -350,6 +350,7 @@ export default function(app) {
       initializedPageSize: boolean;
       initializedRenderers: boolean;
       pageSize: any; // TODO: remove?
+      textFocused: boolean = false;
 
       // renderer state
       renderedSize: {height: number, width: number};
@@ -444,6 +445,10 @@ export default function(app) {
         this.element.append(popup);
 
         this.initializedRenderers = true;
+
+        // should the text layer be focused?
+        if (this.textFocused) this.textFocus();
+
         return true;
       }
 
@@ -525,6 +530,20 @@ export default function(app) {
         }
       }
 
+      textFocus() {
+        this.textFocused = true;
+        if (this.initializedRenderers) {
+          this.textRenderer.element.insertAfter(this.annotationsRenderer.element);
+        }
+      }
+
+      textUnfocus() {
+        this.textFocused = false;
+        if (this.initializedRenderers) {
+          this.textRenderer.element.insertBefore(this.annotationsRenderer.element);
+        }
+      }
+
       unrender() {
         delete this.canvasRenderer;
         delete this.textRenderer;
@@ -550,6 +569,7 @@ export default function(app) {
       lastSimpleSelection: any;
       linkService: LinkService;
       anchor: string;
+      textFocused: boolean = false;
 
       constructor(public pdf: PDFDocumentProxy, public element: JQuery,
           public scope: any) {
@@ -935,6 +955,16 @@ export default function(app) {
 
         // set selection
         this.onSelect(response.data.target.selectors);
+      }
+
+      textFocus() {
+        this.textFocused = true;
+        this.pages.forEach(page => page.textFocus());
+      }
+
+      textUnfocus() {
+        this.textFocused = false;
+        this.pages.forEach(page => page.textUnfocus());
       }
 
       updateHighlights() {

--- a/less/paperhive/pdf.less
+++ b/less/paperhive/pdf.less
@@ -91,6 +91,10 @@ pdf-full {
   }
 }
 
+.ph-no-interaction {
+  pointer-events: none;
+}
+
 
 .ph-popup-button {
   position: absolute;


### PR DESCRIPTION
* re-enable `annotationsLayer`: adds links from PDFs to internal (same PDF) and external destinations (actual hyperlinks)
* scroll to internal destination when link is clicked or when document is opened (named destination deep link)
* clicking an internal link updates the anchor URL parameter accordingly
* links can be selected
   * if the selection starts outside a link
   * or if the user holds CTRL+ALT when starting the selection

Two interesting documents for testing the PR:
* https://dev.paperhive.org/frontend/pdf-links/documents/aZUPQYAYFBDz: features a lot of internal links that are made visible with colored borders
* https://dev.paperhive.org/frontend/pdf-links/documents/2OyBDh_UJAFd?a=p:5: ideal for testing CTRL+ALT in the table of contents