### PR TITLE
Allow Cmd (Mac) and Ctrl+Alt (everything else) for PDF links

### DIFF
--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -618,8 +618,8 @@ export default function(app) {
         // focus text layer while ctrl+alt is pressed
         // note: key events are not fired on PDFs
         const onKeyEvent = event => {
-          const ctrlAlt = event.altKey && event.ctrlKey;
-          if (ctrlAlt) this.textFocus();
+          const shouldFocus = event.altKey && event.ctrlKey || event.metaKey;
+          if (shouldFocus) this.textFocus();
           else if (!mousedown) {
             this.textUnfocus();
             if (event.type === 'keyup') this.onTextSelect();

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -292,11 +292,13 @@ export default function(app) {
         // TODO: use angular here?
         this.element.find('section').on('dragstart', event => {
           if (this.tooltip) this.tooltip.remove();
+          const isMac = /Mac/.test($window.navigator.platform);
           this.tooltip = jquery(
             `<div class="tooltip top fade" role="tooltip">
               <div class="tooltip-arrow"></div>
               <div class="tooltip-inner">
-                Press and hold Ctrl+Alt to select text inside a link.
+                Press and hold ${isMac ? 'Cmd' : 'Ctrl+Alt'} to select text
+                inside a link.
               </div>
             </div>`
           );

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -297,7 +297,7 @@ export default function(app) {
             `<div class="tooltip top fade" role="tooltip">
               <div class="tooltip-arrow"></div>
               <div class="tooltip-inner">
-                Press and hold ${isMac ? 'Cmd' : 'Ctrl+Alt'} to select text
+                Press and hold ${isMac ? 'cmd (⌘)' : 'Ctrl+Alt'} to select text
                 inside a link.
               </div>
             </div>`

--- a/app/directives/pdf.ts
+++ b/app/directives/pdf.ts
@@ -905,9 +905,21 @@ export default function(app) {
         if (!destRef) throw new Error(`destination ${dest} not found`);
         if (!isArray(destRef)) throw new Error('destination does not resolve to array');
 
-        if (destRef[1].name !== 'XYZ') {
-          console.warn(`destination is of type ${destRef[1].name} instead of XYZ`);
-          return;
+        let top;
+        switch (destRef[1].name) {
+          case 'XYZ':
+            top = destRef[3];
+            break;
+          case 'FitH':
+          case 'FitBH':
+            top = destRef[2];
+            break;
+          case 'FitR':
+            top = destRef[5];
+            break;
+          default:
+            console.warn(`destination type ${destRef[1].name} is not supported`);
+            return;
         }
 
         const pageNumber = await this.pdf.getPageIndex(destRef[0]);
@@ -916,13 +928,13 @@ export default function(app) {
           throw new Error('page number out of bounds');
         }
 
-        if (destRef[2] === null || destRef[3] === null) {
+        if (top === null || top === undefined) {
           console.warn('ignoring destination without coordinates');
           return;
         }
         const page = this.pages[pageNumber];
         if (!page.pageSize) throw new Error('pageSize not available');
-        const coords = page.pageSize.convertToViewportPoint(destRef[2], destRef[3]);
+        const coords = page.pageSize.convertToViewportPoint(0, top);
 
         scroll.scrollTo(
           this.element.offset().top +


### PR DESCRIPTION
Reason: Ctrl+Alt is used for something else on Macs.

@gruberb can you test https://dev.paperhive.org/frontend/pdf-links-mac/documents/2OyBDh_UJAFd (after the jenkins build finished)? Thx!