### PR TITLE
add /documents/remote route

### DIFF
--- a/app/components/document-remote.ts
+++ b/app/components/document-remote.ts
@@ -1,34 +1,27 @@
 import { get } from 'lodash';
 
-class DocumentRedirectCtrl {
+class DocumentRemoteCtrl {
   static $inject =
     ['$http', '$location', '$routeSegment', 'config', 'notificationService'];
   constructor($http, $location, $routeSegment, config, notificationService) {
-    // get url parameter
-    const url = $location.search().url;
-    if (!url) {
+    // get type and id parameter
+    const type = $location.search().type;
+    const id = $location.search().id;
+    if (!type || !id) {
       notificationService.notifications.push({
         type: 'error',
-        message: 'URL parameter is missing.'
+        message: 'type or id parameter is missing.'
       });
       return;
     }
 
     // determine document
     $http({
-      url: `${config.apiUrl}/documents/search`,
-      params: {url},
+      url: `${config.apiUrl}/documents/remote`,
+      params: {type, id},
     }).then(
       response => {
-        // do we have a document?
-        const document = get(response, 'data.documents[0]');
-        if (!document) {
-          notificationService.notifications.push({
-            type: 'error',
-            message: `No document found for URL ${url}.`
-          });
-          return;
-        }
+        const document = response.data;
 
         // get target URL
         const targetUrl = $routeSegment.getSegmentUrl('documents.revisions', {
@@ -43,7 +36,7 @@ class DocumentRedirectCtrl {
         notificationService.notifications.push({
           type: 'error',
           message: response.data && response.data.message ||
-            `Obtaining document for URL ${url} failed for an unknown reason.`
+            `Document with type ${type} and id ${id} could not be retrieved for an unknown reason.`
         });
       }
     );
@@ -51,7 +44,7 @@ class DocumentRedirectCtrl {
 }
 
 export default function(app) {
-  app.component('documentRedirect', {
-    controller: DocumentRedirectCtrl
+  app.component('documentRemote', {
+    controller: DocumentRemoteCtrl
   });
 }

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -10,7 +10,7 @@ import discussionThreadView from './discussion-thread-view';
 import document from './document';
 import documentItem from './document-item';
 import documentNew from './document-new';
-import documentRedirect from './document-redirect';
+import documentRemote from './document-remote';
 import documentText from './document-text';
 import documentsList from './documents-list';
 import extensionButtons from './extension-buttons';
@@ -75,7 +75,7 @@ export default function(app) {
   document(app);
   documentItem(app);
   documentNew(app);
-  documentRedirect(app);
+  documentRemote(app);
   documentText(app);
   documentsList(app);
   extensionButtons(app);

--- a/app/config/routes.ts
+++ b/app/config/routes.ts
@@ -27,9 +27,9 @@ export default function(app) {
         .when('/404', '404')
         .when('/about', 'about')
         .when('/auth/return/:provider', 'authReturn')
-        // register new and redirect before id-dependent routes
+        // register new and remote before id-dependent routes
         .when('/documents/new', 'documents_new')
-        .when('/documents/redirect', 'documents_redirect')
+        .when('/documents/remote', 'documents_remote')
         .when('/documents/:documentId', 'documents', {reloadOnSearch: false})
         .when('/documents/:documentId/activity', 'documents.activity')
         .when('/documents/:documentId/discussions', 'documents.discussions')
@@ -197,9 +197,9 @@ export default function(app) {
           template: '<document-new></document-new>',
           title: 'Add a new document · PaperHive'
         })
-        .segment('documents_redirect', {
-          template: '<document-redirect></document-redirect>',
-          title: 'Document redirect · PaperHive'
+        .segment('documents_remote', {
+          template: '<document-remote></document-remote>',
+          title: 'Document remote redirect · PaperHive'
         })
 
         .segment('contact', {


### PR DESCRIPTION
This PR uses the `/documents/remote` API endpoint and redirects users to the corresponding document. Example: `https://dev.paperhive.org/frontend/remote/documents/remote?type=langsci&id=103` will redirect to `https://dev.paperhive.org/frontend/remote/documents/2OyBDh_UJAFd/revisions/wp5BdtMVCnVW`. 

The old `document-redirect` component has been replaced with `document-remote`.