### PR TITLE
Revert "gulp: instantiate imagemin plugins manually"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,9 +9,6 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var htmlmin = require('gulp-htmlmin');
 var imagemin = require('gulp-imagemin');
-var imageminJpegtran = require('imagemin-jpegtran');
-var imageminOptipng = require('imagemin-optipng');
-var imageminSvgo = require('imagemin-svgo');
 var merge = require('merge-stream');
 var rename = require('gulp-rename');
 var streamify = require('gulp-streamify');
@@ -85,9 +82,9 @@ gulp.task('html', function() {
 gulp.task('static', [], function() {
   return gulp.src(paths.staticFiles)
     .pipe(imagemin([
-      imageminJpegtran(),
-      imageminOptipng(),
-      imageminSvgo({plugins: [{removeViewBox: false}, {minifyStyles: false}]}),
+      imagemin.jpegtran(),
+      imagemin.optipng(),
+      imagemin.svgo({plugins: [{removeViewBox: false}, {minifyStyles: false}]}),
     ], {verbose: true}))
     //.pipe(dev ? gutil.noop() : cachebust.resources())
     .pipe(gulp.dest(buildDir + '/static'));


### PR DESCRIPTION
This reverts commit 1d6aa41c7cddca0fc547afa5aa2ad208fe6c3f2c. 

Note: gulp-imagemin fixed the options handling in https://github.com/sindresorhus/gulp-imagemin/pull/231.