### PR TITLE
Opensearch integration

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -179,12 +179,15 @@ gulp.task('vendor', [], function() {
 // Depend on 'js' and 'style' since file names here are changed by the cache
 // buster and referenced in index.html.
 gulp.task('index', function() {
-  return gulp.src(paths.index, {base: 'src'})
-    .pipe(template({
-      config: config,
-      dev: dev
-    }))
-    .pipe(dev ? gutil.noop() : htmlmin(htmlminOpts))
-    .pipe(rename('index.html'))
-    .pipe(gulp.dest(dev ? 'build-dev' : 'build'));
+  return merge(
+    gulp.src(paths.index, {base: 'src'})
+      .pipe(template({
+        config: config,
+        dev: dev
+      }))
+      .pipe(dev ? gutil.noop() : htmlmin(htmlminOpts))
+      .pipe(rename('index.html'))
+      .pipe(gulp.dest(dev ? 'build-dev' : 'build')),
+    gulp.src('opensearch.xml').pipe(gulp.dest(dev ? 'build-dev' : 'build'))
+  );
 });

--- a/index.template.html
+++ b/index.template.html
@@ -17,6 +17,7 @@ NOTE: ng-app is removed because angular is loaded asynchronously via
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta ng-repeat="meta in metaService.data.meta" attributes="meta">
 
+    <link rel="search" type="application/opensearchdescription+xml" href="./opensearch.xml" title="PaperHive search" />
     <!-- favicons -->
     <link rel="apple-touch-icon" sizes="57x57" href="./static/favicons/apple-touch-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="./static/favicons/apple-touch-icon-60x60.png">

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+   <ShortName>PaperHive</ShortName>
+   <Description>Search PaperHive</Description>
+   <Image height="16" width="16" type="image/x-icon">https://paperhive.org/static/favicons/favicon.ico</Image>
+   <Url type="text/html" method="get" template="https://paperhive.org/search?query={searchTerms}"/>
+</OpenSearchDescription>

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
    <ShortName>PaperHive</ShortName>
    <Description>Search PaperHive</Description>
-   <Image height="16" width="16" type="image/x-icon">https://paperhive.org/static/favicons/favicon.ico</Image>
+   <InputEncoding>UTF-8</InputEncoding>
+   <Image height="64" width="64" type="image/x-icon">https://paperhive.org/static/favicons/favicon.ico</Image>
    <Url type="text/html" method="get" template="https://paperhive.org/search?query={searchTerms}"/>
+   <moz:SearchForm>https://paperhive.org/search</moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
- add opensearch integration (for chrome and firefox)
- unfortunately it's not yet working on chrome, because we insist on https: "In order to allow chrome to auto-discover the opensearch description xml document, one must request the site over a non-secure HTTPS connection at least once." (see https://bugs.chromium.org/p/chromium/issues/detail?id=245988)
