### PR TITLE
tsconfig: enable skipLibCheck as workaround for broken lodash typings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
     "target": "es6",
     "types": ["node"]
   },


### PR DESCRIPTION
see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324

fixes #648, #646, and #640