### PR TITLE
Add crossref member filter

### DIFF
--- a/app/components/search.ts
+++ b/app/components/search.ts
@@ -292,6 +292,12 @@ export default function(app) {
           apiParameters: {term: 'openAccess', missing: 'openAccessMissing'},
           urlParameters: {term: 'access', missing: 'accessMissing'},
         }),
+        crossrefMember: new TermsFilter({
+          onUpdate: this.updateCtrlParams.bind(this),
+          type: 'string',
+          apiParameters: {term: 'crossrefMember', missing: 'crossrefMemberMissing'},
+          urlParameters: {term: 'crossrefMember', missing: 'crossrefMemberMissing'},
+        }),
         documentType: new TermsFilter({
           onUpdate: this.updateCtrlParams.bind(this),
           type: 'string',

--- a/app/components/search.ts
+++ b/app/components/search.ts
@@ -400,6 +400,13 @@ export default function(app) {
       updateFromLocation() {
         const search = this.$location.search();
 
+        // redirect for springer
+        const {remoteType} = search;
+        if (remoteType === 'springer') {
+          delete search.remoteType;
+          search.crossrefMember = '297';
+        }
+
         const query = search.query;
 
         // set query input model


### PR DESCRIPTION
Also adds a redirect for `springer` remote type (which is now `crossref`)